### PR TITLE
[Server] Mediawiki docker container

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,11 +50,21 @@ load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 container_deps()
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
+
+# Pull postgres base container
 container_pull(
     name = "psql",
     registry = "index.docker.io",
     repository = "library/postgres",
     digest = "sha256:29351fa971769c793d19e75e98c71ca7e00ad981267bcd99590862917eea2713" # postgres:latest
+)
+
+# Pull MediaWiki base container
+container_pull(
+    name = "mediawiki",
+    registry = "index.docker.io",
+    repository = "library/mediawiki",
+    digest = "sha256:944d0c01466de418d57e0a0182f1b30a22872050f7383f8ce541701828336110" # mediawiki:latest
 )
 
 load(

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -47,3 +47,9 @@ container_image(
     name = "database",
     base = "@psql//image",
 )
+
+# Mediawiki container
+container_image(
+    name = "wiki",
+    base = "@mediawiki//image"
+)

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -3,6 +3,7 @@ package(default_visibility=["//visibility:public"])
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("@io_bazel_rules_docker//nodejs:image.bzl", "nodejs_image")
 load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit")
 load("@npm//typescript:index.bzl", "tsc")
 load("@npm//@bazel/typescript:index.bzl", "ts_library")
 
@@ -48,8 +49,22 @@ container_image(
     base = "@psql//image",
 )
 
-# Mediawiki container
+# Mediawiki container set-up
+container_run_and_commit(
+    name = "wiki_base",
+    image = "@mediawiki//image",
+    # install postgres drivers
+    commands = [
+        "apt-get update",
+        "apt-get install --no-install-recommends -y libpq-dev",
+        "docker-php-ext-install pgsql",
+        "apt-get clean",
+        "rm -rf /var/lib/apt/lists/*",
+    ],
+)
+
+# Wiki container
 container_image(
     name = "wiki",
-    base = "@mediawiki//image"
+    base = ":wiki_base",
 )

--- a/server/docker-compose.yml
+++ b/server/docker-compose.yml
@@ -7,12 +7,35 @@ services:
         environment:
             POSTGRES_DB: default
             POSTGRES_PASSWORD: secret
+        ports:
+            - 5432:5432
     api:
         image: bazel/server:api
         container_name: api
+        restart: always
         environment: 
             DB_HOST: db
             DB_DATABASE: default
             DB_PASSWORD: secret
+        links:
+            - db
         ports: 
             - 4000:4000
+    wiki:
+        image: bazel/server:wiki
+        container_name: wiki
+        restart: always
+        environment:
+            DB_HOST: db
+            DB_DATABASE: default
+            DB_PASSWORD: secret
+        ports:
+            - 8080:80
+        links:
+            - db
+        # volumes:
+        #     # - /var/www/html/images # Media uploads are a threat vector. Limit arbitrary file uploading
+        #     # After initial setup, download LocalSettings.php to the same directory as
+        #     # this yaml and uncomment the following line and use compose to restart
+        #     # the mediawiki service
+        #     - ./LocalSettings.php:/var/www/html/LocalSettings.php


### PR DESCRIPTION
Was kind of a mess to wrangle, but I got a Mediawiki docker container successfully talking to my postgres container.

The trick was having an image that install php-posgres drivers after pulling. 

Some problems still on the horizon though: 
* I don't persist my postgres container data so I blow away whatever tables mediawiki configures during installation, leading to DB errors. Need to fix that
* I should save a LocalSettings.php and share that file with the MediaWiki container as a volume. Then I can start studying how I can link wiki pages with tables used to power the Chrome extension API