### PR TITLE
[DevOps] Manage utility scripts with Bazel also

### DIFF
--- a/scripts/BUILD.bazel
+++ b/scripts/BUILD.bazel
@@ -1,0 +1,12 @@
+package(default_visibility=["//visibility:public"])
+
+sh_binary(
+    name = "dc",
+    srcs = ["dc.sh"],
+    data = [
+        "//server:api",
+        "//server:wiki",
+        "//server:database",
+        "//server:docker-compose.yml",
+    ],
+)

--- a/scripts/dc
+++ b/scripts/dc
@@ -1,15 +1,3 @@
 #!/bin/bash
 
-arg=$1
-
-echo $arg
-
-if [ "$arg" == "up" ];
-then
-cd server; docker-compose --file docker-compose.yml up --detach; cd -
-fi
-
-if [ "$arg" == "down" ];
-then
-cd server; docker-compose down --remove-orphans; cd -
-fi
+bazel run //scripts:dc $@

--- a/scripts/dc.sh
+++ b/scripts/dc.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -euo pipefail
+
+arg=$1
+
+# If 'up', set up dev server
+if [ "$arg" == "up" ];
+then
+    cd server; docker-compose --file docker-compose.yml up --detach; cd -
+    exit 0
+fi
+
+# If 'down', tear down dev server
+if [ "$arg" == "down" ];
+then
+    cd server; docker-compose down --remove-orphans; cd -
+    exit 0
+fi
+
+echo "ERROR: Input must be 'up' or 'down'"
+exit 1

--- a/server/BUILD.bazel
+++ b/server/BUILD.bazel
@@ -1,4 +1,5 @@
 package(default_visibility=["//visibility:public"])
+exports_files(["docker-compose.yml"], visibility = ["//visibility:public"])
 
 load("@build_bazel_rules_nodejs//:index.bzl", "nodejs_binary")
 load("@io_bazel_rules_docker//nodejs:image.bzl", "nodejs_image")


### PR DESCRIPTION
Saving myself a little headache and capturing script deps with Bazel as well.

Now if any of my server Docker images change or `docker-compose.yml` changes, those changes should automatically be captured when I rerun server-related scripts. Huge time saver! yey